### PR TITLE
Meilisearch Pagination, API-Key and Searchindex

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog], and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
 
+== {compare}/Unreleased\...main[5.0.0]
+
+=== Changed
+
+*
+
+
 == {compare}/v4.0.0\...main[Unreleased]
 
 == {compare}/v3.0.1\...v4.0.0[4.0.0]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,9 +12,9 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog], a
 
 === Changed
 
-* add new named constant ROTARACT_MEILISEARCH_SEARCHINDEX
-* changed named constant ROTARACT_MEILISEARCH_API_KEY to ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY
-* updated Meilisearch Filter
+* A new named constant has been created with the name ROTARACT_MEILISEARCH_SEARCHINDEX. This must be defined in wp-config.php. This allows to change the search index for Meilisearch quickly and easily
+* The named constant ROTARACT_MEILISEARCH_API_KEY has been renamed to ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY. The reason for this is that each Wordpress plugin should have its own API key.
+* The 'limit' attribute has been added to the Meilisearch Fiter. This can be used to specify the number of data records found. The limit is currently set to 25.
 
 == {compare}/v4.0.0\...main[Unreleased]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,6 @@
 = Changelog
 
-:repo: https://github.com/rotaract/rotaract-appointments
+:repo: https://github.com/rotaract/rotaract-club-finder
 :compare: {repo}/compare
 :github-pr: {repo}/pull
 
@@ -12,8 +12,9 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog], a
 
 === Changed
 
-*
-
+* add new named constant ROTARACT_MEILISEARCH_SEARCHINDEX
+* changed named constant ROTARACT_MEILISEARCH_API_KEY to ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY
+* updated Meilisearch Filter
 
 == {compare}/v4.0.0\...main[Unreleased]
 

--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,8 @@ IMPORTANT: The plugin's latest version is already installed at https://hosting.r
 [source, php]
 ----
 define( 'ROTARACT_MEILISEARCH_URL', 'https://search.rotaract.de' );
-define( 'ROTARACT_MEILISEARCH_API_KEY', '<your-meiliseach-api-key>' );
+define( 'ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY', '<your-meiliseach-api-key>' );
+define( 'ROTARACT_MEILISEARCH_SEARCHINDEX', 'Club_public');
 ----
   * The Meilisearch API key is required to have `search` permission on index `Club`
 . Set OpenCage API key in your `wp-config.php`, used to convert geocode to geopoint data

--- a/includes/callers/class-rotaract-club-finder-meilisearch-caller.php
+++ b/includes/callers/class-rotaract-club-finder-meilisearch-caller.php
@@ -41,11 +41,11 @@ class Rotaract_Club_Finder_Meilisearch_Caller {
 	 */
 	public function __construct() {
 		if (
-			defined( 'ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY' ) &&
-			defined( 'ROTARACT_MEILISEARCH_URL' ) &&
-			defined( 'ROTARACT_MEILISEARCH_SEARCHINDEX' )
+			defined( 'ROTARACT_CLUBFINDER_MEILISEARCH_KEY' ) &&
+			defined( 'ROTARACT_CLUBFINDER_MEILISEARCH_URL' ) &&
+			defined( 'ROTARACT_CLUBFINDER_MEILISEARCH_SEARCHINDEX' )
 		) {
-			$this->client = new Client( ROTARACT_MEILISEARCH_URL, ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY );
+			$this->client = new Client( ROTARACT_CLUBFINDER_MEILISEARCH_URL, ROTARACT_MEILISEARCH_CLUBFINDER_KEY );
 		}
 	}
 
@@ -73,7 +73,7 @@ class Rotaract_Club_Finder_Meilisearch_Caller {
 		if ( ! $this->isset_client() ) {
 			return array();
 		}
-		return $this->client->index( ROTARACT_MEILISEARCH_SEARCHINDEX )->search( '', $filter )->getHits();
+		return $this->client->index( ROTARACT_CLUBFINDER_MEILISEARCH_SEARCHINDEX )->search( '', $filter )->getHits();
 	}
 
 	/**

--- a/includes/callers/class-rotaract-club-finder-meilisearch-caller.php
+++ b/includes/callers/class-rotaract-club-finder-meilisearch-caller.php
@@ -41,11 +41,11 @@ class Rotaract_Club_Finder_Meilisearch_Caller {
 	 */
 	public function __construct() {
 		if (
-			defined( 'ROTARACT_MEILISEARCH_API_KEY' ) &&
+			defined( 'ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY' ) &&
 			defined( 'ROTARACT_MEILISEARCH_URL' ) &&
 			defined( 'ROTARACT_MEILISEARCH_SEARCHINDEX' )
 		) {
-			$this->client = new Client( ROTARACT_MEILISEARCH_URL, ROTARACT_MEILISEARCH_API_KEY );
+			$this->client = new Client( ROTARACT_MEILISEARCH_URL, ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY );
 		}
 	}
 

--- a/includes/callers/class-rotaract-club-finder-meilisearch-caller.php
+++ b/includes/callers/class-rotaract-club-finder-meilisearch-caller.php
@@ -42,7 +42,8 @@ class Rotaract_Club_Finder_Meilisearch_Caller {
 	public function __construct() {
 		if (
 			defined( 'ROTARACT_MEILISEARCH_API_KEY' ) &&
-			defined( 'ROTARACT_MEILISEARCH_URL' )
+			defined( 'ROTARACT_MEILISEARCH_URL' ) &&
+			defined( 'ROTARACT_MEILISEARCH_SEARCHINDEX' )
 		) {
 			$this->client = new Client( ROTARACT_MEILISEARCH_URL, ROTARACT_MEILISEARCH_API_KEY );
 		}
@@ -72,8 +73,7 @@ class Rotaract_Club_Finder_Meilisearch_Caller {
 		if ( ! $this->isset_client() ) {
 			return array();
 		}
-
-		return $this->client->index( 'Club' )->search( '', $filter )->getHits();
+		return $this->client->index( ROTARACT_MEILISEARCH_SEARCHINDEX )->search( '', $filter )->getHits();
 	}
 
 	/**
@@ -89,6 +89,7 @@ class Rotaract_Club_Finder_Meilisearch_Caller {
 	public function get_clubs( $latitude, $longitude, $range ) {
 		$filter = array(
 			'filter' => '_geoRadius(' . $latitude . ',' . $longitude . ', ' . $range . ')',
+			'limit'  => 25,
 		);
 		return $this->meili_request( $filter );
 	}


### PR DESCRIPTION
- add named constant ROTARACT_MEILISEARCH_SEARCHINDEX to switch Meilisearch index
- add pagination parameter 'limit' to Meiliseach Filter, to tackle Ticket#3514348 (set limit: 25)
- changed named constant ROTARACT_MEILISEARCH_API_KEY to ROTARACT_MEILISEARCH_CLUBFINDER_API_KEY