### PR TITLE
Harden club search: safe rendering, AJAX error handling, i18n strings

### DIFF
--- a/includes/callers/class-rotaract-opencage-caller.php
+++ b/includes/callers/class-rotaract-opencage-caller.php
@@ -72,7 +72,7 @@ class Rotaract_OpenCage_Caller {
 			return array();
 		}
 
-		$res      = wp_remote_get(
+		$res = wp_remote_get(
 			$this->opencage_api_url,
 			array(
 				'headers' => array(
@@ -85,12 +85,21 @@ class Rotaract_OpenCage_Caller {
 				),
 			)
 		);
-		$res_body = wp_remote_retrieve_body( $res );
 
-		$result = json_decode( $res_body )->results[0]->geometry;
+		if ( is_wp_error( $res ) ) {
+			return array();
+		}
+
+		$decoded = json_decode( wp_remote_retrieve_body( $res ) );
+
+		if ( null === $decoded || empty( $decoded->results ) ) {
+			return array();
+		}
+
+		$geometry = $decoded->results[0]->geometry;
 		return array(
-			'lat' => $result->lat,
-			'lng' => $result->lng,
+			'lat' => $geometry->lat,
+			'lng' => $geometry->lng,
 		);
 	}
 }

--- a/public/class-rotaract-club-finder-public.php
+++ b/public/class-rotaract-club-finder-public.php
@@ -129,6 +129,14 @@ class Rotaract_Club_Finder_Public {
 				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
 				'nonce'   => wp_create_nonce( $this->rotaract_club_finder ),
 				'icon'    => plugins_url( 'images/rac-marker.svg', __DIR__ ),
+				'i18n'    => array(
+					'clubPrefix'      => __( 'RAC', 'rotaract-club-finder' ),
+					'district'        => __( 'Distrikt', 'rotaract-club-finder' ),
+					'clubPage'        => __( 'zur Clubseite', 'rotaract-club-finder' ),
+					'searchResults'   => __( 'Suchergebnisse', 'rotaract-club-finder' ),
+					'locationUnknown' => __( 'Ort nicht gefunden. Bitte einen anderen Suchbegriff versuchen.', 'rotaract-club-finder' ),
+					'searchError'     => __( 'Bei der Suche ist ein Fehler aufgetreten. Bitte später erneut versuchen.', 'rotaract-club-finder' ),
+				),
 			)
 		);
 
@@ -154,21 +162,32 @@ class Rotaract_Club_Finder_Public {
 	public function find_clubs_in_range(): void {
 		check_ajax_referer( $this->rotaract_club_finder );
 		if ( ! isset( $_POST['location'], $_POST['range'] ) ) {
+			wp_send_json_error( array( 'message' => 'Missing parameters.' ) );
 			return;
 		}
 		$location = sanitize_text_field( wp_unslash( $_POST['location'] ) );
-		$range    = sanitize_text_field( wp_unslash( $_POST['range'] ) );
+		$range    = (int) sanitize_text_field( wp_unslash( $_POST['range'] ) );
 
-		$geodata        = $this->opencage_caller->opencage_request( $location );
+		if ( ! in_array( $range, array( 5, 10, 20, 50, 100 ), true ) ) {
+			wp_send_json_error( array( 'message' => 'Invalid range.' ) );
+			return;
+		}
+
+		$geodata = $this->opencage_caller->opencage_request( $location );
+		if ( empty( $geodata ) ) {
+			wp_send_json_error( array( 'message' => 'Location not found.' ) );
+			return;
+		}
+
 		$clubs_by_meili = $this->meilisearch_caller->get_clubs( $geodata['lat'], $geodata['lng'], $range * 1000 );
 
 		wp_send_json_success(
 			array(
-				'latitude: '  => $geodata['lat'],
-				'longitude: ' => $geodata['lng'],
-				'range: '     => $range * 1000,
-				'meilidata'   => $clubs_by_meili,
-				'geodata'     => $geodata,
+				'latitude'  => $geodata['lat'],
+				'longitude' => $geodata['lng'],
+				'range'     => $range * 1000,
+				'meilidata' => $clubs_by_meili,
+				'geodata'   => $geodata,
 			)
 		);
 	}

--- a/public/js/public.js
+++ b/public/js/public.js
@@ -21,6 +21,28 @@ L.tileLayer(
 	}
 ).addTo( clubFinderMap );
 
+function districtLabel( club ) {
+	return scriptData.i18n.district + ' ' + ( club['district'] ? club['district'].substring( 1 ) : '' );
+}
+
+function buildClubPopup( club ) {
+	const content     = document.createElement( 'div' );
+	const title       = document.createElement( 'b' );
+	title.textContent = scriptData.i18n.clubPrefix + ' ' + club['name'];
+	content.appendChild( title );
+	content.appendChild( document.createElement( 'br' ) );
+	content.appendChild( document.createTextNode( districtLabel( club ) ) );
+	if (club['homepage_url']) {
+		content.appendChild( document.createElement( 'br' ) );
+		const link       = document.createElement( 'a' );
+		link.href        = club['homepage_url'];
+		link.target      = '_blank';
+		link.textContent = scriptData.i18n.clubPage;
+		content.appendChild( link );
+	}
+	return content;
+}
+
 function initMap( searchedLocation = {}, markers = {} ) {
 	// Set default search parameter.
 	let center = { lat: 51.186867, lng: 10.0575056 }; // Center of Germany.
@@ -28,7 +50,7 @@ function initMap( searchedLocation = {}, markers = {} ) {
 
 	if (Object.entries( searchedLocation ).length !== 0 && searchedLocation.constructor === Object) {
 		center      = searchedLocation;
-		const range = document.getElementById( 'club-finder-range' ).value  // In kilometer.
+		const range = document.getElementById( 'club-finder-range' ).value;  // In kilometer.
 		switch (range) {
 			case '5':
 				zoom = 11.5;
@@ -49,22 +71,22 @@ function initMap( searchedLocation = {}, markers = {} ) {
 	}
 	clubFinderMap.setView( Object.values( center ), zoom );
 
-	const icon = L.icon({
-		iconUrl: scriptData.icon,
-		iconSize: [ 60, 60 ]
-	});
+	const icon = L.icon(
+		{
+			iconUrl: scriptData.icon,
+			iconSize: [ 60, 60 ]
+		}
+	);
 
 	clubFinderLayers.clearLayers();
-	Object.values( markers ).forEach(club => {
-		let text   = `<p><b>RAC ${club['name']}</b><br>Distrikt ${club['district']?.substring( 1 )}</p>`;
-		if (club['homepage_url']) {
-			text += `<p><a href="${club['homepage_url']}" target="_blank">zur Clubseite</a></p>`;
+	Object.values( markers ).forEach(
+		function ( club ) {
+			L.marker(
+				[ parseFloat( club['_geo']['lat'] ), parseFloat( club['_geo']['lng'] ) ],
+				{ icon }
+			).bindPopup( buildClubPopup( club ) ).addTo( clubFinderLayers );
 		}
-		L.marker(
-			[ parseFloat( club['_geo']['lat'] ), parseFloat( club['_geo']['lng'] )],
-			{ icon }
-		).bindPopup( text ).addTo( clubFinderLayers );
-	});
+	);
 }
 initMap();
 
@@ -72,28 +94,60 @@ function handleResults( data ) {
 	const meili          = data.data.meilidata;
 	const searchLocation = data.data.geodata;
 
+	const list      = document.getElementById( 'club-finder-list' );
 	const clubCount = Object.keys( meili ).length;
-	let text        = '';
+
+	list.replaceChildren();
+
 	if (clubCount > 0) {
-		text = `<h3>Sucherergebnisse <small style="font-weight: normal;">(${clubCount})</small></h3>`;
-	}
-	for (let i = 0; i < clubCount; i++) {
-		let club = meili[i];
-		text += '<div class="club-finder-list-line">' +
-				'<div class="club-finder-list-name">' +
-				`<b>RAC ${club['name']}</b><br>` +
-				`<span class="district">Distrikt ${club['district']?.substring( 1 )}</span>` +
-				'</div>';
-		if (club['homepage_url']) {
-			text += '<div class="club-finder-list-link">' +
-					`<a href="${club['homepage_url']}" target="_blank">zur Clubseite</a>` +
-					'</div>';
-		}
-		text += '</div>';
+		const heading          = document.createElement( 'h3' );
+		const count            = document.createElement( 'small' );
+		count.style.fontWeight = 'normal';
+		count.textContent      = '(' + clubCount + ')';
+		heading.textContent    = scriptData.i18n.searchResults + ' ';
+		heading.appendChild( count );
+		list.appendChild( heading );
 	}
 
-	document.getElementById( 'club-finder-list' ).innerHTML = text;
+	for (let i = 0; i < clubCount; i++) {
+		const club    = meili[i];
+		const row     = document.createElement( 'div' );
+		row.className = 'club-finder-list-line';
+
+		const nameDiv     = document.createElement( 'div' );
+		nameDiv.className = 'club-finder-list-name';
+		const bold        = document.createElement( 'b' );
+		bold.textContent  = scriptData.i18n.clubPrefix + ' ' + club['name'];
+		nameDiv.appendChild( bold );
+		nameDiv.appendChild( document.createElement( 'br' ) );
+		const district       = document.createElement( 'span' );
+		district.className   = 'district';
+		district.textContent = districtLabel( club );
+		nameDiv.appendChild( district );
+		row.appendChild( nameDiv );
+
+		if (club['homepage_url']) {
+			const linkDiv     = document.createElement( 'div' );
+			linkDiv.className = 'club-finder-list-link';
+			const link        = document.createElement( 'a' );
+			link.href         = club['homepage_url'];
+			link.target       = '_blank';
+			link.textContent  = scriptData.i18n.clubPage;
+			linkDiv.appendChild( link );
+			row.appendChild( linkDiv );
+		}
+
+		list.appendChild( row );
+	}
+
 	initMap( searchLocation, meili );
+}
+
+function showError( message ) {
+	const list        = document.getElementById( 'club-finder-list' );
+	const error       = document.createElement( 'p' );
+	error.textContent = message;
+	list.replaceChildren( error );
 }
 
 function searchClubs( event ) {
@@ -109,8 +163,22 @@ function searchClubs( event ) {
 			location: searchLocation,
 			range: range
 		},
-		handleResults,
 		'json'
+	).done(
+		function ( data ) {
+			if (data.success) {
+				handleResults( data );
+			} else {
+				const msg = data.data && data.data.message === 'Location not found.'
+					? scriptData.i18n.locationUnknown
+					: scriptData.i18n.searchError;
+				showError( msg );
+			}
+		}
+	).fail(
+		function () {
+			showError( scriptData.i18n.searchError );
+		}
 	);
 }
 


### PR DESCRIPTION
Build marker popups and result list rows via DOM APIs instead of concatenating club names into HTML/template-literal strings, which also avoided the PHPCS JS tokenizer misparsing the embedded tags.

Handle OpenCage/AJAX failures explicitly (missing/invalid params, unreachable API, no results) and surface them to the user instead of failing silently or fataling on an unexpected response shape.

Move the German user-facing strings behind scriptData.i18n so they render the same in the map popups and the results list.